### PR TITLE
39 FAD decomposition & specparam integration

### DIFF
--- a/docs/architecture_diagram.md
+++ b/docs/architecture_diagram.md
@@ -265,7 +265,7 @@ hyperscanning-signal-analysis/
 │   ├── data_structures.py         # MultimodalData class
 │   ├── eyetracker.py              # ET-specific processing
 │   ├── utils.py                   # Plotting & utility functions
-    └── mtmvar.py                  # DTF computation, FAD decomposition
+│   └── mtmvar.py                  # DTF computation, FAD decomposition
 │
 ├── scripts/
 │   ├── mne_export_demo.ipynb      # MNE export examples
@@ -273,7 +273,9 @@ hyperscanning-signal-analysis/
 │   ├── filter_demo.ipynb          # Filter design & testing
 │   ├── decimation_test.ipynb      # Decimation testing
 │   ├── EEG_ET_synch_test.ipynb    # Synchronization checks
-│   ├── Example_DataLoader_usage.ipynb    ├── fad_demo_w030_fz.ipynb     # FAD vs specparam demo (W_030 EEG)│   └── warsaw_pilot_data.py       # Analysis pipeline
+│   ├── Example_DataLoader_usage.ipynb
+│   ├── fad_demo_w030_fz.ipynb     # FAD vs specparam demo (W_030 EEG)
+│   └── warsaw_pilot_data.py       # Analysis pipeline
 │
 ├── tests/
 │   ├── test_dataloader.py

--- a/docs/architecture_diagram.md
+++ b/docs/architecture_diagram.md
@@ -54,6 +54,7 @@ flowchart TB
         HRV["HRV Analysis<br/>- IBI signals<br/>- DTF computation"]
         EEG_A["EEG Analysis<br/>- Multi-channel DTF<br/>- Spectral analysis"]
         COMB["Combined Analysis<br/>- EEG + HRV DTF<br/>- Theta band extraction"]
+        FAD_SPEC["Spectral Component Analysis<br/>- FAD decomposition (AR-based)<br/>- specparam / FOOOF<br/>- Oscillatory component extraction"]
     end
 
     %% Main data flow
@@ -87,7 +88,9 @@ flowchart TB
     GS --> HRV
     GS --> EEG_A
     GS --> COMB
+    GS --> FAD_SPEC
     GD --> EEG_A
+    GD --> FAD_SPEC
     
     GME --> EXT["External Tools<br/>(MNE-Python)"]
 
@@ -98,6 +101,7 @@ flowchart TB
     style PostProcess fill:#e1bee7
     style Output fill:#fff9c4
     style Analysis fill:#ffe0b2
+    style FAD_SPEC fill:#fce4ec
 ```
 
 ## Detailed Component Diagram
@@ -261,7 +265,7 @@ hyperscanning-signal-analysis/
 │   ├── data_structures.py         # MultimodalData class
 │   ├── eyetracker.py              # ET-specific processing
 │   ├── utils.py                   # Plotting & utility functions
-│   └── mtmvar.py                  # DTF computation
+    └── mtmvar.py                  # DTF computation, FAD decomposition
 │
 ├── scripts/
 │   ├── mne_export_demo.ipynb      # MNE export examples
@@ -269,8 +273,7 @@ hyperscanning-signal-analysis/
 │   ├── filter_demo.ipynb          # Filter design & testing
 │   ├── decimation_test.ipynb      # Decimation testing
 │   ├── EEG_ET_synch_test.ipynb    # Synchronization checks
-│   ├── Example_DataLoader_usage.ipynb
-│   └── warsaw_pilot_data.py       # Analysis pipeline
+│   ├── Example_DataLoader_usage.ipynb    ├── fad_demo_w030_fz.ipynb     # FAD vs specparam demo (W_030 EEG)│   └── warsaw_pilot_data.py       # Analysis pipeline
 │
 ├── tests/
 │   ├── test_dataloader.py
@@ -278,6 +281,7 @@ hyperscanning-signal-analysis/
 │
 └── docs/
     ├── data_structure_spec.md
+    ├── fad_specparam_guide.md       # FAD decomposition & specparam guide
     └── architecture_diagram.md     # This file
 ```
 

--- a/docs/fad_specparam_guide.md
+++ b/docs/fad_specparam_guide.md
@@ -1,0 +1,176 @@
+# FAD Decomposition & specparam Guide
+
+**Version:** 1.0  
+**Last updated:** 2026-04-10  
+**Author:** Jarosław Żygierewicz
+
+---
+
+## Overview
+
+This guide describes two complementary methods for extracting oscillatory components from EEG power spectra:
+
+| Method | Module / Package | Input | Approach |
+|--------|-----------------|-------|----------|
+| **FAD** (Frequency-Amplitude-Damping) | `src/mtmvar.py` | raw time series | AR model + partial fraction decomposition |
+| **specparam** (formerly FOOOF) | `specparam` (pip) | pre-computed power spectrum | Gaussian peak fitting on 1/f-adjusted spectrum |
+
+Both approaches are demonstrated in `scripts/fad_demo_w030_fz.ipynb` using the W_030 caregiver Brave EEG signal (Fz / Pz channel).
+
+---
+
+## FAD Decomposition
+
+### Background
+
+FAD decomposes the impulse response of a univariate AR model into exponentially damped oscillators:
+
+$$h(t) = \sum_j B_j \cdot e^{-\beta_j t} \cos(\omega_j t + \varphi_j)$$
+
+Each component is characterised by:
+
+| Symbol | Key in output dict | Unit | Description |
+|--------|--------------------|------|-------------|
+| $f_j$ | `freq_hz` | Hz | Resonance frequency |
+| $B_j = 2\|C_j\|$ | `B` | signal units | Amplitude |
+| $\beta_j$ | `beta` | s⁻¹ | Damping coefficient (positive = decay) |
+| $\Delta f_j = \beta_j / (2\pi)$ | `bandwidth_hz` | Hz | Half-power bandwidth proxy |
+| $\varphi_j$ | `phi` | rad | Initial phase |
+
+The approach follows the partial-fraction expansion of the AR transfer function:
+
+$$H(z) = \sum_j \frac{C_j \cdot z}{z - z_j}, \quad \alpha_j = \frac{\ln z_j}{\Delta t}$$
+
+Reference: Blinowska & Żygierewicz, *Practical Biomedical Signal Analysis*, 2nd ed.
+
+### API
+
+```python
+from src.mtmvar import fad_decomposition, fad_components_table
+
+fad = fad_decomposition(
+    signal,                # 1-D array, shape (N,)
+    fs=fs,                 # sampling frequency [Hz]
+    model_order=None,      # None → automatic selection via crit_type
+    max_model_order=12,    # upper bound for automatic search
+    crit_type='AIC',       # 'AIC' | 'HQ' | 'SC'
+    plot=True,             # show pole plot + AR spectrum
+    pair_conjugates=True,  # report one oscillator per conjugate pair
+)
+
+# Compact DataFrame (one row per oscillatory component)
+df = fad_components_table(fad, output='dataframe', decimals=4)
+```
+
+### Output structure
+
+`fad_decomposition` returns a dict. The most useful sub-structures are:
+
+```
+fad['model_order']          # int — selected AR order p
+fad['paired_components']    # dict — one oscillator per conjugate pair
+    ['freq_hz']             # ndarray — frequencies in Hz (sorted)
+    ['B']                   # ndarray — amplitudes
+    ['beta']                # ndarray — damping coefficients [s⁻¹]
+    ['bandwidth_hz']        # ndarray — bandwidths [Hz]
+    ['phi']                 # ndarray — phases [rad]
+    ['poles']               # ndarray — complex poles z_j
+fad['noise_variance']       # float — residual AR noise variance
+fad['ar_coeffs']            # ndarray (p,) — fitted AR coefficients
+```
+
+### Model order selection
+
+Automatic order selection evaluates AIC (or HQ / SC) for orders 1 … `max_model_order` and picks the minimum. A plot of the criterion vs. order is shown when `plot=True`.
+
+Typical values for EEG (250–1024 Hz, bandpass 1–40 Hz): p = 6–16.
+
+---
+
+## specparam (formerly FOOOF)
+
+### Background
+
+`specparam` models the power spectrum as a sum of an aperiodic (1/f) component and one or more Gaussian peaks:
+
+$$\log P(f) = L(f) + \sum_k G_k(f)$$
+
+where $L(f)$ is a Lorentzian/knee model for the aperiodic background and $G_k$ are Gaussian peaks representing oscillatory components.
+
+Package: **specparam 2.x** (`pip install specparam`)  
+Documentation: https://specparam-tools.github.io/
+
+### Quick start
+
+```python
+from specparam import SpectralModel
+from scipy.signal import welch
+
+# Compute PSD
+freqs, psd = welch(x, fs=fs, nperseg=4*fs)
+
+# Fit specparam model
+sm = SpectralModel(
+    peak_width_limits=[1.0, 8.0],  # [Hz] min/max peak width
+    max_n_peaks=6,
+    min_peak_height=0.1,
+    aperiodic_mode='fixed',        # 'fixed' | 'knee'
+    verbose=False,
+)
+sm.fit(freqs, psd, freq_range=[1, 45])
+sm.report()                        # print + plot
+
+# Access results
+print(sm.aperiodic_params_)        # [offset, exponent]  (or [offset, knee, exponent])
+print(sm.peak_params_)             # [[CF, PW, BW], ...]
+```
+
+### Key output parameters
+
+| Attribute | Description |
+|-----------|-------------|
+| `aperiodic_params_` | `[offset, exponent]` (fixed) or `[offset, knee, exponent]` (knee) |
+| `peak_params_` | `[[CF (Hz), PW (log power), BW (Hz)], …]` per peak |
+| `r_squared_` | goodness of fit ($R^2$) |
+| `error_` | mean absolute error on log power |
+
+---
+
+## FAD vs specparam: comparison
+
+| Property | FAD | specparam |
+|----------|-----|-----------|
+| Input | Raw time series | Pre-computed PSD |
+| Aperiodic removal | Implicit (AR captures 1/f trend) | Explicit Lorentzian/knee fit |
+| Frequency resolution | Continuous (pole-based) | Limited by FFT resolution |
+| Damping / bandwidth | Direct output ($\beta$, $\Delta f$) | Peak width BW (Gaussian σ) |
+| Phase information | Yes ($\varphi_j$) | No |
+| Model order choice | Required (automatic via AIC) | `max_n_peaks`, `peak_width_limits` |
+| Multiple channels | Extend to MVAR for connectivity | Run per-channel independently |
+| Package dependency | `scipy` only (via `src/mtmvar.py`) | `specparam` |
+
+### Practical guidance
+
+- **Use FAD** when you need phase estimates, damping constants, or when the data segment is short (AR is data-efficient).
+- **Use specparam** when you want to cleanly separate aperiodic slope from peaks, compare peak center frequencies across conditions, or integrate with MNE/BIDS pipelines.
+- The two methods can be run in parallel: FAD frequencies and specparam CF values for the same channel should agree within ±0.5 Hz for well-resolved peaks.
+
+---
+
+## Demo notebook
+
+`scripts/fad_demo_w030_fz.ipynb` — end-to-end example:
+
+1. Load W_030 EEG (caregiver, Brave) from NetCDF.
+2. Run `fad_decomposition` on the Pz channel.
+3. Display FAD component table.
+4. Fit `SpectralModel` (specparam) on the Welch PSD of the same signal.
+5. Compare component frequencies side by side.
+
+---
+
+## References
+
+- Franaszczuk, P. J., Bergey, G. K., & Kamiński, M. J. (1994). Analysis of mesial temporal seizure onset and propagation using the directed transfer function method. *Electroencephalography and Clinical Neurophysiology*, 91(6), 413–427.
+- Blinowska, K. J., & Żygierewicz, J. (2011). *Practical Biomedical Signal Analysis Using MATLAB®*. CRC Press.
+- Donoghue, T., Haller, M., Peterson, E. J., Varma, P., Sebastian, P., Gao, R., … Voytek, B. (2020). Parameterizing neural power spectra into periodic and aperiodic components. *Nature Neuroscience*, 23, 1655–1665. https://doi.org/10.1038/s41593-020-00744-x

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ neurokit2==0.2.12
 mne==1.11.0
 autoreject
 PyWavelets==1.9.0
+specparam==2.0.0rc6
 
 # Visualization
 matplotlib==3.10.8
@@ -20,18 +21,15 @@ ipympl==0.10.0
 # Data handling
 xmltodict==1.0.2
 joblib==1.5.3
-xarray==2025.10.1
+xarray==2026.2.0
 netCDF4==1.7.4
-networkx
+networkx==3.6.1
 
 # Jupyter notebook support
 ipykernel==7.1.0
 ipython==9.9.0
 ipywidgets==8.1.8
 jupyter_client==8.8.0
-
-# Network analysis
-networkx
 
 # Utilities
 tqdm==4.67.1

--- a/scripts/fad_demo_w030_fz.ipynb
+++ b/scripts/fad_demo_w030_fz.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3d524706",
+   "metadata": {},
+   "source": [
+    "# FAD Demo on W_030 EEG (caregiver, Brave)\n",
+    "\n",
+    "This notebook mirrors the FAD workflow from the MATLAB live-script idea, using the local NetCDF EEG data and the new Python FAD implementation in src/mtmvar.py.\n",
+    "\n",
+    "Signal used: Fz channel from data/UNIWAW_imported/EEG/W_030/caregiver/W_030_EEG_cg_Brave.nc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2f0cf65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "sys.path.insert(0, os.path.abspath('..'))\n",
+    "\n",
+    "from src.mtmvar import fad_decomposition, fad_components_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "239f7357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load EEG dataset\n",
+    "nc_path = '../data/UNIWAW_imported/EEG/W_030/caregiver/W_030_EEG_cg_Brave.nc'\n",
+    "ds = xr.open_dataset(nc_path)\n",
+    "selected_channel = 'Pz'  # Change as needed\n",
+    "# The file has one main data variable with a descriptive name\n",
+    "var_name = list(ds.data_vars)[0]\n",
+    "sig = ds[var_name]\n",
+    "\n",
+    "# Select channel\n",
+    "if 'channel' not in sig.dims:\n",
+    "    raise ValueError(\"Expected channel dim, got: %s\" % (sig.dims,))\n",
+    "if selected_channel not in ds['channel'].values:\n",
+    "    raise ValueError('Channel %s not found in dataset' % selected_channel)\n",
+    "\n",
+    "x = sig.sel(channel=selected_channel).values.astype(float)\n",
+    "t = ds['time'].values.astype(float)\n",
+    "\n",
+    "# Estimate sampling frequency from time coordinate\n",
+    "dt = float(np.median(np.diff(t)))\n",
+    "fs = 1.0 / dt\n",
+    "\n",
+    "print('Variable:', var_name)\n",
+    "print('Signal shape:', x.shape)\n",
+    "print('Estimated fs: %.6f Hz' % fs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edb68193",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick view of the signal\n",
+    "plt.figure(figsize=(12, 3))\n",
+    "plt.plot(t, x, lw=0.8)\n",
+    "plt.title(f'W_030 EEG caregiver Brave - {selected_channel} channel')\n",
+    "plt.xlabel('Time [s]')\n",
+    "plt.ylabel('Amplitude')\n",
+    "plt.grid(alpha=0.3)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2acd411f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FAD decomposition\n",
+    "# model_order=None => automatic order selection by AIC over max_model_order\n",
+    "fad = fad_decomposition(\n",
+    "    x,\n",
+    "    fs=fs,\n",
+    "    model_order=None,\n",
+    "    max_model_order=12,\n",
+    "    crit_type='AIC',\n",
+    "    plot=True,\n",
+    "    pair_conjugates=True\n",
+    ")\n",
+    "\n",
+    "print('Selected AR order:', fad['model_order'])\n",
+    "print('Number of oscillatory components (paired):', len(fad['paired_components']['freq_hz']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23cd0f91",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f54c1f56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compact FAD table (DataFrame)\n",
+    "fad_df = fad_components_table(fad, output='dataframe', decimals=6)\n",
+    "fad_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb9988e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional export for downstream analysis\n",
+    "#out_csv = 'fad_w030_fz_components.csv'\n",
+    "#fad_df.to_csv(out_csv, index=False)\n",
+    "#print('Saved:', out_csv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d3e82e5",
+   "metadata": {},
+   "source": [
+    "Compare with FOOOF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29bf7949",
+   "metadata": {},
+   "source": [
+    "# Import the FOOOF object\n",
+    "from fooof import FOOOF"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv_SYNCCIN_local_FUW",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/fad_demo_w030_fz.ipynb
+++ b/scripts/fad_demo_w030_fz.ipynb
@@ -41,7 +41,7 @@
     "# Load EEG dataset\n",
     "nc_path = '../data/UNIWAW_imported/EEG/W_030/caregiver/W_030_EEG_cg_Brave.nc'\n",
     "ds = xr.open_dataset(nc_path)\n",
-    "selected_channel = 'Pz'  # Change as needed\n",
+    "selected_channel = 'Fz'  # Change as needed\n",
     "# The file has one main data variable with a descriptive name\n",
     "var_name = list(ds.data_vars)[0]\n",
     "sig = ds[var_name]\n",
@@ -143,17 +143,19 @@
    "id": "5d3e82e5",
    "metadata": {},
    "source": [
-    "Compare with FOOOF"
+    "## Compare with specparam"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
    "id": "29bf7949",
    "metadata": {},
    "source": [
-    "# Import the FOOOF object\n",
-    "from fooof import FOOOF"
-   ]
+    "# Import the specparam spectral model\n",
+    "from specparam import SpectralModel"
+   ],
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/src/mtmvar.py
+++ b/src/mtmvar.py
@@ -613,12 +613,12 @@ def fad_decomposition(signal, fs, model_order=None, max_model_order=20,
     Fits an AR model to the signal and decomposes the transfer function H(z) into
     oscillatory components. Each component is characterised by:
 
-    - freq_hz  : resonance frequency (Hz)
-    - B        : amplitude  B_j = 2|C_j|
-        - beta     : damping coefficient (s⁻¹);  positive = exponential decay
-        - bandwidth_hz : half-power bandwidth proxy in Hz, matching the MATLAB
-            FAD script convention: bandwidth_hz = beta / (2*pi)
-    - phi      : initial phase (rad)
+    - freq_hz      : resonance frequency (Hz)
+    - B            : amplitude  B_j = 2|C_j|
+    - beta         : damping coefficient (s⁻¹);  positive = exponential decay
+    - bandwidth_hz : half-power bandwidth proxy in Hz, matching the MATLAB
+                     FAD script convention: bandwidth_hz = beta / (2*pi)
+    - phi          : initial phase (rad)
 
     The impulse response of the AR model is:
         h(t) = Σ_j  B_j · exp(−β_j · t) · cos(ω_j · t + φ_j)
@@ -791,7 +791,7 @@ def fad_components_table(fad_params, output='dataframe', decimals=None):
         raise ValueError("fad_params does not contain 'paired_components'.")
 
     n = len(paired['freq_hz'])
-    component = np.arange(1, n + 1, dtype=float)
+    component = np.arange(1, n + 1, dtype=int)
 
     table = np.column_stack([
         component,
@@ -835,7 +835,9 @@ def fad_components_table(fad_params, output='dataframe', decimals=None):
             'residue_real',
             'residue_imag',
         ]
-        return pd.DataFrame(table, columns=columns)
+        df = pd.DataFrame(table, columns=columns)
+        df['component'] = df['component'].astype(int)
+        return df
 
     raise ValueError("output must be 'dataframe' or 'ndarray'.")
 
@@ -862,12 +864,15 @@ def _fad_plot(signal, fs, fad_params):
     ar_spectrum = var / np.abs(A_f) ** 2
 
     # Colours for oscillatory components (one per conjugate pair)
+    # Always restrict to the positive-imaginary branch to avoid duplicates
+    # when pair_conjugates=False includes both halves of each conjugate pair.
     if paired is not None and paired['pole_index'].size > 0:
-        pair_idx = paired['pole_index']
-        pair_f = paired['freq_hz']
-        pair_B = paired['B']
-        pair_beta = paired['beta']
-        pair_bw_hz = paired['bandwidth_hz']
+        pos_mask = np.imag(z_poles[paired['pole_index']]) > 1e-8
+        pair_idx = paired['pole_index'][pos_mask]
+        pair_f = paired['freq_hz'][pos_mask]
+        pair_B = paired['B'][pos_mask]
+        pair_beta = paired['beta'][pos_mask]
+        pair_bw_hz = paired['bandwidth_hz'][pos_mask]
     else:
         pair_idx = np.where(np.imag(z_poles) > 1e-8)[0]
         pair_f = freq_hz[pair_idx]

--- a/src/mtmvar.py
+++ b/src/mtmvar.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 MVAR Analysis Functions for EEG Connectivity Analysis
 
@@ -598,6 +599,350 @@ def mvar_criterion(data, max_model_order, crit_type='AIC', plot=False):
         plt.show()
 
     return crit, model_order_range, optimal_model_range
+
+
+# ── FAD decomposition ──────────────────────────────────────────────────────────
+
+
+def fad_decomposition(signal, fs, model_order=None, max_model_order=20,
+                      crit_type='AIC', plot=False, pair_conjugates=True,
+                      imag_tol=1e-8):
+    """
+    FAD (Frequency-Amplitude-Damping) decomposition of a univariate AR model.
+
+    Fits an AR model to the signal and decomposes the transfer function H(z) into
+    oscillatory components. Each component is characterised by:
+
+    - freq_hz  : resonance frequency (Hz)
+    - B        : amplitude  B_j = 2|C_j|
+        - beta     : damping coefficient (s⁻¹);  positive = exponential decay
+        - bandwidth_hz : half-power bandwidth proxy in Hz, matching the MATLAB
+            FAD script convention: bandwidth_hz = beta / (2*pi)
+    - phi      : initial phase (rad)
+
+    The impulse response of the AR model is:
+        h(t) = Σ_j  B_j · exp(−β_j · t) · cos(ω_j · t + φ_j)
+
+    This corresponds to the partial-fraction expansion of the transfer function
+    (Franaszczuk et al., and Blinowska & Żygierewicz, *Practical Biomedical
+    Signal Analysis*, 2nd ed., §FAD):
+
+        H(z) = Σ_j  C_j · z / (z − z_j)
+
+        α_j = ln(z_j) / Δt,   β_j = −Re(α_j),   ω_j = Im(α_j)
+        φ_j = arg(C_j),        B_j = 2|C_j|
+
+    Parameters
+    ----------
+    signal : array_like, shape (N,) or (1, N)
+        Univariate time series.
+    fs : float
+        Sampling frequency [Hz].
+    model_order : int or None
+        AR model order p.  If None the order is chosen automatically via
+        `crit_type`.
+    max_model_order : int
+        Maximum order considered during automatic selection (default 20).
+    crit_type : str
+        Information criterion used for automatic order selection:
+        ``'AIC'`` (default), ``'HQ'``, or ``'SC'``.
+    plot : bool
+        If True, show a two-panel figure: poles in the unit circle (left) and
+        AR power spectrum annotated with FAD component frequencies (right).
+    pair_conjugates : bool
+        If True (default), expose one oscillator per complex-conjugate pole
+        pair in ``paired_components`` (positive-imaginary pole branch).
+        This is the standard FAD reporting style (p/2 oscillators for even p).
+    imag_tol : float
+        Numerical tolerance used to classify poles as complex vs. real.
+
+    Returns
+    -------
+    dict with keys
+        ``'model_order'``   – int, fitted AR order p
+        ``'poles'``         – ndarray (p,), complex poles z_j
+        ``'C'``             – ndarray (p,), complex residues C_j
+        ``'alpha'``         – ndarray (p,), α_j = ln(z_j)/Δt
+        ``'freq_hz'``       – ndarray (p,), resonance frequency [Hz]
+        ``'omega_rad_s'``   – ndarray (p,), angular frequency [rad/s]
+        ``'beta'``          – ndarray (p,), damping coefficient [s⁻¹]
+        ``'phi'``           – ndarray (p,), phase [rad]
+        ``'bandwidth_hz'``  – ndarray (p,), bandwidth in Hz
+        ``'B'``             – ndarray (p,), amplitude B_j = 2|C_j|
+        ``'noise_variance'``– float, residual noise variance σ²
+        ``'osc_mask'``      – bool ndarray (p,), True for complex poles
+        ``'ar_coeffs'``     – ndarray (p,), fitted AR coefficients a_1 … a_p
+        ``'paired_components'`` – dict containing one oscillator per conjugate
+                      pair (frequency, amplitude, damping, phase)
+    """
+    from scipy.signal import residuez
+
+    x = np.atleast_2d(np.asarray(signal, dtype=float))
+    if x.shape[0] != 1:
+        raise ValueError(
+            "fad_decomposition expects a univariate signal, shape (N,) or (1, N)."
+        )
+
+    if model_order is None:
+        _, _, model_order = mvar_criterion(x, max_model_order, crit_type, plot)
+        print(f'FAD: optimal AR model order ({crit_type}) = {model_order}')
+
+    ar_co, variance = ar_coeff(x, model_order)
+    a = ar_co[0, 0, :]  # a_1 … a_p
+
+    # Partial-fraction decomposition of H(z⁻¹) = 1 / A(z⁻¹)
+    # A(z⁻¹) = 1 − a_1·z⁻¹ − … − a_p·z⁻ᵖ
+    a_denom = np.concatenate([[1.0], -a])          # [1, −a₁, …, −aₚ]
+    C, z_poles, _ = residuez(np.array([1.0]), a_denom)
+    # residuez gives:  H = Σ C_j / (1 − z_j·z⁻¹)  =  Σ C_j · z/(z−z_j)
+
+    # FAD parameters (eq. FAD_params in the textbook)
+    dt = 1.0 / fs
+    alpha   = np.log(z_poles) / dt          # α_j = ln(z_j) / Δt
+    beta    = -np.real(alpha)               # β_j = −Re(α_j)  [s⁻¹]
+    omega   =  np.imag(alpha)               # ω_j = Im(α_j)   [rad/s]
+    freq_hz = omega / (2.0 * np.pi)         # f_j              [Hz]
+    phi     = np.angle(C)                   # φ_j = arg(C_j)  [rad]
+    B       = 2.0 * np.abs(C)              # B_j = 2|C_j|
+    bandwidth_hz = beta / (2.0 * np.pi)     # MATLAB-style bandwidth in Hz
+
+    # Oscillatory poles are complex (exclude purely real roots).
+    osc_mask = np.abs(np.imag(z_poles)) > imag_tol
+
+    # One oscillator per conjugate pair: use positive-imaginary branch only.
+    pos_idx = np.where(np.imag(z_poles) > imag_tol)[0]
+    if pos_idx.size > 0:
+        order = np.argsort(freq_hz[pos_idx])
+        pos_idx = pos_idx[order]
+
+    if pair_conjugates:
+        paired_idx = pos_idx
+    else:
+        paired_idx = np.where(osc_mask)[0]
+
+    paired_components = {
+        'pole_index': paired_idx,
+        'poles': z_poles[paired_idx],
+        'C': C[paired_idx],
+        'alpha': alpha[paired_idx],
+        'freq_hz': freq_hz[paired_idx],
+        'omega_rad_s': omega[paired_idx],
+        'beta': beta[paired_idx],
+        'bandwidth_hz': bandwidth_hz[paired_idx],
+        'phi': phi[paired_idx],
+        'B': B[paired_idx],
+    }
+
+    fad_params = {
+        'model_order'   : model_order,
+        'poles'         : z_poles,
+        'C'             : C,
+        'alpha'         : alpha,
+        'freq_hz'       : freq_hz,
+        'omega_rad_s'   : omega,
+        'beta'          : beta,
+        'bandwidth_hz'  : bandwidth_hz,
+        'phi'           : phi,
+        'B'             : B,
+        'noise_variance': float(np.real(variance[0, 0])),
+        'osc_mask'      : osc_mask,
+        'ar_coeffs'     : a,
+        'paired_components': paired_components,
+    }
+
+    if plot:
+        _fad_plot(x.ravel(), fs, fad_params)
+
+    return fad_params
+
+
+def fad_components_table(fad_params, output='dataframe', decimals=None):
+    """
+    Return compact FAD components table for export.
+
+    The function uses ``fad_params['paired_components']`` so each row
+    corresponds to one oscillator (one complex-conjugate pole pair).
+
+    Parameters
+    ----------
+    fad_params : dict
+        Output dictionary returned by ``fad_decomposition``.
+    output : str
+        Output format:
+        - ``'dataframe'`` (default): pandas DataFrame
+        - ``'ndarray'``: numeric ndarray with columns in fixed order
+    decimals : int or None
+        If provided, round numeric values to this number of decimals.
+
+    Returns
+    -------
+    pandas.DataFrame or np.ndarray
+        Table-like representation with columns:
+        [component, freq_hz, omega_rad_s, beta_s_1, bandwidth_hz, B, phi_rad,
+         pole_real, pole_imag, residue_real, residue_imag]
+
+    Notes
+    -----
+    If ``output='dataframe'`` and pandas is not installed, an ImportError
+    is raised. Use ``output='ndarray'`` for a dependency-free export path.
+    """
+    paired = fad_params.get('paired_components', None)
+    if paired is None:
+        raise ValueError("fad_params does not contain 'paired_components'.")
+
+    n = len(paired['freq_hz'])
+    component = np.arange(1, n + 1, dtype=float)
+
+    table = np.column_stack([
+        component,
+        paired['freq_hz'],
+        paired['omega_rad_s'],
+        paired['beta'],
+        paired['bandwidth_hz'],
+        paired['B'],
+        paired['phi'],
+        np.real(paired['poles']),
+        np.imag(paired['poles']),
+        np.real(paired['C']),
+        np.imag(paired['C']),
+    ])
+
+    if decimals is not None:
+        table = np.round(table, decimals=decimals)
+
+    if output == 'ndarray':
+        return table
+
+    if output == 'dataframe':
+        try:
+            import pandas as pd
+        except ImportError as exc:
+            raise ImportError(
+                "pandas is required for output='dataframe'. "
+                "Use output='ndarray' instead."
+            ) from exc
+
+        columns = [
+            'component',
+            'freq_hz',
+            'omega_rad_s',
+            'beta_s_1',
+            'bandwidth_hz',
+            'B',
+            'phi_rad',
+            'pole_real',
+            'pole_imag',
+            'residue_real',
+            'residue_imag',
+        ]
+        return pd.DataFrame(table, columns=columns)
+
+    raise ValueError("output must be 'dataframe' or 'ndarray'.")
+
+
+def _fad_plot(signal, fs, fad_params):
+    """Two-panel FAD plot: poles in the unit circle and annotated AR spectrum."""
+    a           = fad_params['ar_coeffs']
+    model_order = fad_params['model_order']
+    var         = fad_params['noise_variance']
+    z_poles     = fad_params['poles']
+    osc_mask    = fad_params['osc_mask']
+    freq_hz     = fad_params['freq_hz']
+    B           = fad_params['B']
+    beta        = fad_params['beta']
+    bandwidth_hz = fad_params['bandwidth_hz']
+    paired      = fad_params.get('paired_components', None)
+
+    # AR power spectrum: S(f) = σ² / |A(f)|²
+    n_fft  = 2048
+    f_axis = np.linspace(0, fs / 2.0, n_fft // 2 + 1)
+    A_f    = np.ones(len(f_axis), dtype=complex)
+    for m in range(model_order):
+        A_f -= a[m] * np.exp(-(m + 1) * 2j * np.pi * f_axis / fs)
+    ar_spectrum = var / np.abs(A_f) ** 2
+
+    # Colours for oscillatory components (one per conjugate pair)
+    if paired is not None and paired['pole_index'].size > 0:
+        pair_idx = paired['pole_index']
+        pair_f = paired['freq_hz']
+        pair_B = paired['B']
+        pair_beta = paired['beta']
+        pair_bw_hz = paired['bandwidth_hz']
+    else:
+        pair_idx = np.where(np.imag(z_poles) > 1e-8)[0]
+        pair_f = freq_hz[pair_idx]
+        pair_B = B[pair_idx]
+        pair_beta = beta[pair_idx]
+        pair_bw_hz = bandwidth_hz[pair_idx]
+
+    n_osc  = int(len(pair_idx))
+    colors = (plt.cm.viridis(np.linspace(0.15, 0.9, n_osc))
+              if n_osc > 0 else np.empty((0, 4)))
+
+    theta = np.linspace(0, 2 * np.pi, 300)
+    fig, axes = plt.subplots(1, 2, figsize=(13, 5))
+    fig.suptitle(f'FAD decomposition  (AR order p = {model_order})', fontsize=13)
+
+    # ── Panel 1: poles in the complex plane ───────────────────────────────────
+    ax0 = axes[0]
+    ax0.plot(np.cos(theta), np.sin(theta), 'k-', lw=0.9, alpha=0.4)
+    ax0.axhline(0, color='k', lw=0.5, alpha=0.4)
+    ax0.axvline(0, color='k', lw=0.5, alpha=0.4)
+
+    ci = 0
+    pair_set = set(pair_idx.tolist())
+    for j, z in enumerate(z_poles):
+        if j in pair_set:
+            c = colors[ci]
+            ax0.scatter(np.real(z), np.imag(z), color=c, s=70, zorder=5,
+                        label=f'{pair_f[ci]:.2f} Hz')
+            ax0.scatter(np.real(z), -np.imag(z), color=c, s=70, zorder=5,
+                        marker='x')
+            ci += 1
+        elif not osc_mask[j]:
+            ax0.scatter(np.real(z), np.imag(z), color='gray', s=40, zorder=4,
+                        marker='s')
+
+    ax0.set_xlim(-1.25, 1.25)
+    ax0.set_ylim(-1.25, 1.25)
+    ax0.set_aspect('equal')
+    ax0.set_xlabel('Re(z)')
+    ax0.set_ylabel('Im(z)')
+    ax0.set_title('Poles in the complex plane')
+    ax0.legend(fontsize=8, loc='upper left', title='freq [Hz]')
+    ax0.grid(True, alpha=0.3)
+
+    # ── Panel 2: AR power spectrum with FAD annotations ───────────────────────
+    ax1 = axes[1]
+    ax1.plot(f_axis, ar_spectrum, 'k-', lw=1.5, label='AR spectrum')
+
+    for ci, (f, b_val, bt, bw_hz) in enumerate(zip(pair_f, pair_B, pair_beta, pair_bw_hz)):
+        c = colors[ci]
+        peak_idx = np.argmin(np.abs(f_axis - f))
+        peak_power = ar_spectrum[peak_idx]
+        half_power = peak_power / 2.0
+        left_bw = max(0.0, f - bw_hz)
+        right_bw = min(fs / 2.0, f + bw_hz)
+
+        ax1.plot([f, f], [0, peak_power], color='r', lw=1.2, alpha=0.9)
+        ax1.plot([left_bw, right_bw], [half_power, half_power], color='m', lw=1.8, alpha=0.9)
+        ax1.scatter([f], [peak_power], color=c, s=28, zorder=6)
+        ax1.annotate(
+            f'{f:.1f} Hz\nBW={bw_hz:.2f} Hz\nB={b_val:.3g}',
+            xy=(f, peak_power), xytext=(6, 8),
+            textcoords='offset points', fontsize=7, color=c,
+        )
+
+    ax1.set_xlabel('Frequency [Hz]')
+    ax1.set_ylabel('Power spectral density')
+    ax1.set_title('AR power spectrum with peak positions and bandwidth')
+    ax1.set_xlim(0, fs / 2.0)
+    ax1.set_ylim(bottom=0)
+    ax1.grid(True, alpha=0.3)
+    ax1.legend()
+
+    plt.tight_layout()
+    plt.show()
 
 
 # Compute linewidths


### PR DESCRIPTION
## Summary

Implements FAD (Frequency-Amplitude-Damping) decomposition for univariate EEG signals and adds specparam (FOOOF v2) as a complementary spectral analysis tool.

## Changes

### New features
- **FAD decomposition** (`src/mtmvar.py`): `fad_decomposition()` and `fad_components_table()` — AR-based oscillatory component extraction with frequency, amplitude, damping and phase estimates.
- **specparam** added to project dependencies (`requirements.txt`).

### Notebooks
- `scripts/fad_demo_w030_fz.ipynb`: end-to-end demo on W_030 caregiver Brave EEG (Pz channel) — FAD decomposition, component table, and specparam comparison.
- `scripts/secore_hrv_test_demo.ipynb`: minor updates.

### Documentation
- `docs/fad_specparam_guide.md` (new): theory, API reference, output structure, FAD vs specparam comparison table, and literature references.
- `docs/architecture_diagram.md`: Analysis Layer updated with FAD/specparam node; file organisation and `mtmvar.py` description updated.

## Testing
Existing tests pass. FAD functions tested interactively in the demo notebook.